### PR TITLE
fix: more precise alignment for cluster markers

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -64,6 +64,7 @@ export default function App() {
           } = cluster.properties;
 
           if (isCluster) {
+            const markerSize = 10 + (pointCount / points.length) * 20;
             return (
               <Marker
                 key={`cluster-${cluster.id}`}
@@ -73,8 +74,10 @@ export default function App() {
                 <div
                   className="cluster-marker"
                   style={{
-                    width: `${10 + (pointCount / points.length) * 20}px`,
-                    height: `${10 + (pointCount / points.length) * 20}px`
+                    width: `${markerSize}px`,
+                    height: `${markerSize}px`,
+                    marginTop: `-${markerSize / 2}px`,
+                    marginLeft: `-${markerSize / 2}px`
                   }}
                   onClick={() => {
                     const expansionZoom = Math.min(


### PR DESCRIPTION
Thanks for great work. I just wanted to do this small PR to align the cluster markers more precise. It was a small thing I stumbled upon, and thought the main repo should have this fix too, to save some fellow developers some time.

Before
---
![image](https://user-images.githubusercontent.com/3786627/115956234-f6d78c80-a4fb-11eb-958c-9f4b12d7c02e.png)

After
---
![image](https://user-images.githubusercontent.com/3786627/115956237-fccd6d80-a4fb-11eb-8b36-345897e5c036.png)
